### PR TITLE
fix: remove disabled test-wasi from publish job's needs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -359,7 +359,6 @@ jobs:
       - build-freebsd
       - test-macOS-windows-binding
       - test-linux-binding
-      - test-wasi
     steps:
       - uses: actions/checkout@v7
       - name: setup pnpm


### PR DESCRIPTION
test-wasi has if: false (WASI target removed from build matrix), so it never succeeds. GitHub Actions treats a skipped needs job as not satisfying the implicit success() gate, so publish was silently skipped on every push to main.