### PR TITLE
chore: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -369,6 +369,9 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
+      - name: Update npm
+        # npm trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships an older npm.
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: pnpm install
       - name: Download all artifacts
@@ -396,4 +399,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Upgrade npm to latest in the publish job (Node 22's bundled npm 10.9.8 predates npm's OIDC/trusted-publishing support, which needs >= 11.5.1), and drop the NODE_AUTH_TOKEN/NPM_TOKEN fallback now that publishing authenticates via OIDC (id-token: write is already granted at the workflow level). Requires the package to be configured as a Trusted Publisher for this repo+workflow on npmjs.com.